### PR TITLE
[WIP]SSQL関数で文字列連結を使えるように修正

### DIFF
--- a/src/main/java/supersql/codegenerator/FuncArg.java
+++ b/src/main/java/supersql/codegenerator/FuncArg.java
@@ -1,10 +1,12 @@
 package supersql.codegenerator;
 
+import supersql.codegenerator.HTML.HTMLC0;
 import supersql.codegenerator.HTML.HTMLFunction;
 import supersql.codegenerator.Mobile_HTML5.Mobile_HTML5Function;
 import supersql.codegenerator.Mobile_HTML5.Mobile_HTML5_dynamic;
 import supersql.codegenerator.Mobile_HTML5.Mobile_HTML5_stream;
 import supersql.codegenerator.infinitescroll.Infinite_dynamic;
+import supersql.common.Log;
 import supersql.extendclass.ExtList;
 
 
@@ -85,6 +87,8 @@ public class FuncArg {
 		}
 		else if (tfe instanceof Attribute) {
 
+			System.out.println("in Attribute: " + Data);
+
 			//20131118 dynamic
 			if(Mobile_HTML5_dynamic.dynamicDisplay){
 				return Mobile_HTML5_dynamic.dynamicFuncArgProcess(tfe, null, null);
@@ -141,6 +145,14 @@ public class FuncArg {
 ////			return null;
 //			return null;
 			if(HTMLFunction.HTMLFunctionFlag || Mobile_HTML5Function.Mobile_HTML5FunctionFlag){
+				// Concat対策
+				// C0かつその下がHTMLCONCATだったら
+				if (tfe instanceof HTMLC0 && tfe.makele0().getExtListString(1, 0).equals("HTMLCONCAT")) {
+					Log.out("[Found concat in SSQL Function]");
+					Log.out("[TFE le0]: " + tfe.makele0());
+					Log.out("[Data]: " + Data);
+					return ((HTMLC0) tfe).getConcatStr(Data);
+				}
 				return tfe.work(Data);
 			}
 			return null;

--- a/src/main/java/supersql/codegenerator/HTML/HTMLC0.java
+++ b/src/main/java/supersql/codegenerator/HTML/HTMLC0.java
@@ -1,7 +1,6 @@
 package supersql.codegenerator.HTML;
 
 import supersql.codegenerator.Connector;
-import supersql.codegenerator.FuncArg;
 import supersql.codegenerator.Manager;
 import supersql.extendclass.ExtList;
 
@@ -62,6 +61,10 @@ public class HTMLC0 extends Connector {
 		}
 		return (!HTMLFunction.HTMLFunctionFlag)? null : ret;
 //		return null;
+	}
+
+	public String getConcatStr(ExtList data) {
+		return data.stream().reduce("", (l, r) -> l.toString() + r.toString()).toString();
 	}
 
 }

--- a/test_queries/concat_test/image.ssql
+++ b/test_queries/concat_test/image.ssql
@@ -1,0 +1,3 @@
+GENERATE HTML
+[image(e.id || '.p' || 'ng', './picts')]!
+from employee e

--- a/test_queries/concat_test/image2.ssql
+++ b/test_queries/concat_test/image2.ssql
@@ -1,0 +1,4 @@
+GENERATE HTML
+[image(e.id || '.' || ex.extension, './picts')]!
+from employee e, extension ex
+where ex.id = 1

--- a/test_queries/concat_test/image3.ssql
+++ b/test_queries/concat_test/image3.ssql
@@ -1,0 +1,4 @@
+GENERATE HTML
+[e.name, image(e.id || '.' || ex.extension, './picts')]!
+from employee e, extension ex
+where ex.id = 1

--- a/test_queries/concat_test/image4.ssql
+++ b/test_queries/concat_test/image4.ssql
@@ -1,0 +1,4 @@
+GENERATE HTML
+[e.manager ! [e.name, image(e.id || '.' || ex.extension, './picts') ! '給与は' || e.salary || 'です'],]!
+from employee e, extension ex
+where ex.id = 1


### PR DESCRIPTION
## 概要
- SSQL関数で文字列連結を使用できるようにしました。
- SQL関数については一旦対象外としています。

## やったこと
- [FuncArgsでgetStrするとき](https://github.com/ToyamaLab/NewSSQL/blob/feature/enable_to_use_concat_in_ssql_func/src/main/java/supersql/codegenerator/FuncArg.java#L81)に文字列連結してると`tfe.work`が呼ばれてnullが返っていました。
- そのためFuncArgsのtfeがHTMLC0で、その子要素がHTMLCONCATの場合のみconcatしているデータを全部繋げて返すようにしました。

## 見てほしい所
- image関数以外に思い出せなかったので、色々とデバッグして欲しいです。エラーは出そうな予感がしてます。

## 懸念点(解消したらメモしてチェック)
- [ ] 上記のテスト不足
- [ ] 本当にこの実装でいいのか→バグベースで考えようかと思っています

## 動作例
1. 単純な例
```
GENERATE HTML
[image(e.id || '.p' || 'ng', './picts')],
from employee e
```
![image](https://user-images.githubusercontent.com/57790645/121814149-84d52580-ccaa-11eb-819f-43f895ed5e10.png)

2. 属性同士の連結の例
```
GENERATE HTML
ex.extension!
[e.name, image(e.id || '.' || ex.extension, './picts')],
from employee e, extension ex
where ex.id = 1
```
![image](https://user-images.githubusercontent.com/57790645/121814352-8521f080-ccab-11eb-8c6c-7c5f1f0d71dd.png)

3. 他の場所でも文字列連結してる例
```
GENERATE HTML
[e.manager ! [e.name, image(e.id || '.' || ex.extension, './picts') ! '給与は' || e.salary || 'です'],]!
from employee e, extension ex
where ex.id = 1
```
![image](https://user-images.githubusercontent.com/57790645/121814384-c0242400-ccab-11eb-99be-72090fa78064.png)
